### PR TITLE
feat: 统一清空商品相关接口响应中的base64图片内容

### DIFF
--- a/data/item_image.go
+++ b/data/item_image.go
@@ -13,7 +13,7 @@ func AddItemImage(tx *sql.Tx, addItemImage *entity.AddItemImage) error {
 		addItemImage.SnowflakeId,
 		addItemImage.ItemId,
 		addItemImage.Type,
-		addItemImage.Data,
+		addItemImage.Data.String(),
 		addItemImage.Sorting,
 		addItemImage.Ext,
 		addItemImage.ObjectName,

--- a/data/stock_keeping_unit.go
+++ b/data/stock_keeping_unit.go
@@ -23,7 +23,7 @@ func AddSku(tx *sql.Tx, sku *entity.AddSkuRequest) error {
 		sku.ObjectName,
 		sku.BucketName,
 		sku.Ext,
-		sku.ImageData,
+		sku.ImageData.String(),
 	)
 	return err
 }
@@ -42,7 +42,7 @@ func UpdateSku(tx *sql.Tx, sku *entity.UpdateSkuRequest) error {
 		sku.ObjectName,
 		sku.BucketName,
 		sku.Ext,
-		sku.ImageData,
+		sku.ImageData.String(),
 		sku.SnowflakeId)
 	return err
 }

--- a/entity/base64.go
+++ b/entity/base64.go
@@ -1,0 +1,22 @@
+package entity
+
+import "encoding/json"
+
+type Base64String string
+
+func (b Base64String) MarshalJSON() ([]byte, error) {
+	return json.Marshal("")
+}
+
+func (b *Base64String) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*b = Base64String(s)
+	return nil
+}
+
+func (b Base64String) String() string {
+	return string(b)
+}

--- a/entity/item.go
+++ b/entity/item.go
@@ -13,14 +13,14 @@ type AddItem struct {
 }
 
 type Picture struct {
-	SnowflakeId string `json:"snowflake_id"`
-	ItemId      string `json:"item_id"`
-	Type        uint8  `json:"type"`
-	ImageData   string `json:"image_data"`
-	Sorting     uint8  `json:"sorting"`
-	Ext         string `json:"ext"`
-	ObjectName  string `json:"object_name"`
-	BucketName  string `json:"bucket_name"`
+	SnowflakeId string       `json:"snowflake_id"`
+	ItemId      string       `json:"item_id"`
+	Type        uint8        `json:"type"`
+	ImageData   Base64String `json:"image_data"`
+	Sorting     uint8        `json:"sorting"`
+	Ext         string       `json:"ext"`
+	ObjectName  string       `json:"object_name"`
+	BucketName  string       `json:"bucket_name"`
 }
 
 type UpdateItem struct {

--- a/entity/item_image.go
+++ b/entity/item_image.go
@@ -1,12 +1,12 @@
 package entity
 
 type AddItemImage struct {
-	SnowflakeId string `json:"snowflake_id"`
-	ItemId      string `json:"item_id"`
-	Type        uint8  `json:"type"`
-	Data        string `json:"data"`
-	Sorting     uint8  `json:"sorting"`
-	ObjectName  string `json:"object_name"`
-	BucketName  string `json:"bucket_name"`
-	Ext         string `json:"ext"`
+	SnowflakeId string       `json:"snowflake_id"`
+	ItemId      string       `json:"item_id"`
+	Type        uint8        `json:"type"`
+	Data        Base64String `json:"data"`
+	Sorting     uint8        `json:"sorting"`
+	ObjectName  string       `json:"object_name"`
+	BucketName  string       `json:"bucket_name"`
+	Ext         string       `json:"ext"`
 }

--- a/entity/stock_keeping_unit.go
+++ b/entity/stock_keeping_unit.go
@@ -1,35 +1,35 @@
 package entity
 
 type AddSkuRequest struct {
-	SnowflakeId   string  `json:"snowflake_id"`
-	Code          string  `json:"code"`
-	Name          string  `json:"name"`
-	StockQuantity int64   `json:"stock_quantity"`
-	VirtualSales  int64   `json:"virtual_sales"`
-	Price         float64 `json:"price"`
-	Status        int64   `json:"status"`
-	Sorting       int64   `json:"sorting"`
-	ItemId        string  `json:"item_id"`
-	ImageData     string  `json:"image_data"`
-	ObjectName    string  `json:"object_name"`
-	BucketName    string  `json:"bucket_name"`
-	Ext           string  `json:"ext"`
+	SnowflakeId   string       `json:"snowflake_id"`
+	Code          string       `json:"code"`
+	Name          string       `json:"name"`
+	StockQuantity int64        `json:"stock_quantity"`
+	VirtualSales  int64        `json:"virtual_sales"`
+	Price         float64      `json:"price"`
+	Status        int64        `json:"status"`
+	Sorting       int64        `json:"sorting"`
+	ItemId        string       `json:"item_id"`
+	ImageData     Base64String `json:"image_data"`
+	ObjectName    string       `json:"object_name"`
+	BucketName    string       `json:"bucket_name"`
+	Ext           string       `json:"ext"`
 }
 
 type UpdateSkuRequest struct {
-	SnowflakeId   string  `json:"snowflake_id"`
-	Code          string  `json:"code"`
-	Name          string  `json:"name"`
-	StockQuantity int64   `json:"stock_quantity"`
-	VirtualSales  int64   `json:"virtual_sales"`
-	Price         float64 `json:"price"`
-	Status        int64   `json:"status"`
-	Sorting       int64   `json:"sorting"`
-	ItemId        string  `json:"item_id"`
-	ImageData     string  `json:"image_data"`
-	ObjectName    string  `json:"object_name"`
-	BucketName    string  `json:"bucket_name"`
-	Ext           string  `json:"ext"`
+	SnowflakeId   string       `json:"snowflake_id"`
+	Code          string       `json:"code"`
+	Name          string       `json:"name"`
+	StockQuantity int64        `json:"stock_quantity"`
+	VirtualSales  int64        `json:"virtual_sales"`
+	Price         float64      `json:"price"`
+	Status        int64        `json:"status"`
+	Sorting       int64        `json:"sorting"`
+	ItemId        string       `json:"item_id"`
+	ImageData     Base64String `json:"image_data"`
+	ObjectName    string       `json:"object_name"`
+	BucketName    string       `json:"bucket_name"`
+	Ext           string       `json:"ext"`
 }
 
 type ShowSkuResponse struct {
@@ -45,22 +45,22 @@ type ShowSkuResponse struct {
 }
 
 type Sku struct {
-	SnowflakeId   string  `json:"snowflake_id"`
-	Code          string  `json:"code"`
-	Name          string  `json:"name"`
-	StockQuantity int64   `json:"stock_quantity"`
-	VirtualSales  int64   `json:"virtual_sales"`
-	Price         float64 `json:"price"`
-	Status        int64   `json:"status"`
-	Sorting       int64   `json:"sorting"`
-	ItemId        string  `json:"item_id"`
-	ObjectName    string  `json:"object_name"`
-	BucketName    string  `json:"bucket_name"`
-	Ext           string  `json:"ext"`
-	ImageData     string  `json:"image_data"`
-	CreatedAt     string  `json:"created_at"`
-	UpdatedAt     string  `json:"updated_at"`
-	ActualSales   int64   `json:"actual_sales"`
+	SnowflakeId   string       `json:"snowflake_id"`
+	Code          string       `json:"code"`
+	Name          string       `json:"name"`
+	StockQuantity int64        `json:"stock_quantity"`
+	VirtualSales  int64        `json:"virtual_sales"`
+	Price         float64      `json:"price"`
+	Status        int64        `json:"status"`
+	Sorting       int64        `json:"sorting"`
+	ItemId        string       `json:"item_id"`
+	ObjectName    string       `json:"object_name"`
+	BucketName    string       `json:"bucket_name"`
+	Ext           string       `json:"ext"`
+	ImageData     Base64String `json:"image_data"`
+	CreatedAt     string       `json:"created_at"`
+	UpdatedAt     string       `json:"updated_at"`
+	ActualSales   int64        `json:"actual_sales"`
 }
 
 type GetSkuRequest struct {

--- a/rest/pc/item.go
+++ b/rest/pc/item.go
@@ -216,7 +216,7 @@ func AddItem(c fiber.Ctx) error {
 
 	for _, picture := range addItem.Picture {
 
-		imageData := []byte(picture.ImageData)
+		imageData := []byte(picture.ImageData.String())
 
 		hash.Write(imageData)
 
@@ -235,7 +235,7 @@ func AddItem(c fiber.Ctx) error {
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 		}
 
-		imageBytes, err := base64.StdEncoding.DecodeString(picture.ImageData)
+		imageBytes, err := base64.StdEncoding.DecodeString(picture.ImageData.String())
 		if err != nil {
 			tx.Rollback()
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})
@@ -268,7 +268,7 @@ func AddItem(c fiber.Ctx) error {
 
 	for _, detail := range addItem.Detail {
 
-		imageData := []byte(detail.ImageData)
+		imageData := []byte(detail.ImageData.String())
 
 		hash.Write(imageData)
 
@@ -287,7 +287,7 @@ func AddItem(c fiber.Ctx) error {
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 		}
 
-		imageBytes, err := base64.StdEncoding.DecodeString(detail.ImageData)
+		imageBytes, err := base64.StdEncoding.DecodeString(detail.ImageData.String())
 		if err != nil {
 			tx.Rollback()
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})
@@ -419,7 +419,7 @@ func UpdateItem(c fiber.Ctx) error {
 
 	for _, picture := range updateItem.Picture {
 
-		imageData := []byte(picture.ImageData)
+		imageData := []byte(picture.ImageData.String())
 
 		hash.Write(imageData)
 
@@ -438,7 +438,7 @@ func UpdateItem(c fiber.Ctx) error {
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 		}
 
-		imageBytes, err := base64.StdEncoding.DecodeString(picture.ImageData)
+		imageBytes, err := base64.StdEncoding.DecodeString(picture.ImageData.String())
 		if err != nil {
 			tx.Rollback()
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})
@@ -471,7 +471,7 @@ func UpdateItem(c fiber.Ctx) error {
 
 	for _, detail := range updateItem.Detail {
 
-		imageData := []byte(detail.ImageData)
+		imageData := []byte(detail.ImageData.String())
 
 		hash.Write(imageData)
 
@@ -490,7 +490,7 @@ func UpdateItem(c fiber.Ctx) error {
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 		}
 
-		imageBytes, err := base64.StdEncoding.DecodeString(detail.ImageData)
+		imageBytes, err := base64.StdEncoding.DecodeString(detail.ImageData.String())
 		if err != nil {
 			tx.Rollback()
 			panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})

--- a/rest/pc/stock_keeping_unit.go
+++ b/rest/pc/stock_keeping_unit.go
@@ -186,7 +186,7 @@ func AddSku(c fiber.Ctx) error {
 
 	payload.BucketName = "dongle"
 
-	imageData := []byte(payload.ImageData)
+	imageData := []byte(payload.ImageData.String())
 
 	hash.Write(imageData)
 
@@ -205,7 +205,7 @@ func AddSku(c fiber.Ctx) error {
 		panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 	}
 
-	imageBytes, err := base64.StdEncoding.DecodeString(payload.ImageData)
+	imageBytes, err := base64.StdEncoding.DecodeString(payload.ImageData.String())
 	if err != nil {
 		tx.Rollback()
 		panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})
@@ -344,7 +344,7 @@ func UpdateSku(c fiber.Ctx) error {
 
 	payload.BucketName = "dongle"
 
-	imageData := []byte(payload.ImageData)
+	imageData := []byte(payload.ImageData.String())
 
 	hash.Write(imageData)
 
@@ -363,7 +363,7 @@ func UpdateSku(c fiber.Ctx) error {
 		panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 MIME 类型: %v, 必须是图片类型", err)})
 	}
 
-	imageBytes, err := base64.StdEncoding.DecodeString(payload.ImageData)
+	imageBytes, err := base64.StdEncoding.DecodeString(payload.ImageData.String())
 	if err != nil {
 		tx.Rollback()
 		panic(tools.CustomError{Code: 50001, Message: fmt.Sprintf("无效的 Base64 编码: %v", err)})


### PR DESCRIPTION
## 修改说明

### 背景
统一调整商品相关接口的响应内容：凡是响应 JSON 中包含图片或文件的 base64 内容，一律保留字段，但值统一置为空字符串 ""。

### 实现方案
采用自定义类型 `entity.Base64String` 在序列化层统一处理，避免在单个接口零散修改。

### 技术实现
1. **新增 `entity/base64.go`**
   - 定义 `Base64String` 自定义类型
   - 实现 `MarshalJSON` 方法，序列化时返回空字符串
   - 实现 `UnmarshalJSON` 方法，反序列化时保留原始值（用于请求处理）

2. **修改实体类型**
   - `entity.Picture.ImageData` 改为 `Base64String` 类型
   - `entity.Sku.ImageData` 改为 `Base64String` 类型
   - `entity.AddItemImage.Data` 改为 `Base64String` 类型

3. **更新数据处理层**
   - `data/item_image.go` - 更新 AddItemImage 函数
   - `data/stock_keeping_unit.go` - 更新 AddSku/UpdateSku 函数

4. **更新接口处理层**
   - `rest/pc/item.go` - 更新 AddItem/UpdateItem 处理逻辑
   - `rest/pc/stock_keeping_unit.go` - 更新 SKU 添加/更新逻辑

### 影响范围

#### PC端接口
| 接口 | 文件 | 说明 |
|------|------|------|
| 商品列表 | `rest/pc/item.go` | GetItemList |
| 商品详情 | `rest/pc/item.go` | ShowItem |
| 商品分类列表 | `rest/pc/product_categories.go` | GetProductCategoriesList |
| SKU列表 | `rest/pc/stock_keeping_unit.go` | GetSkuList |

#### 小程序端接口
| 接口 | 文件 | 说明 |
|------|------|------|
| 产品组列表 | `rest/mini/get_product_group_list.go` | GetProductGroupList |
| 购物车列表 | `rest/mini/cart.go` | CartIndex |
| 订单列表 | `rest/mini/get_order_list.go` | GetOrderList |
| 订单详情 | `rest/mini/get_order_detail.go` | GetOrderDetail |

### 修改文件清单
- `entity/base64.go` (新增)
- `entity/item.go`
- `entity/item_image.go`
- `entity/stock_keeping_unit.go`
- `data/item_image.go`
- `data/stock_keeping_unit.go`
- `rest/pc/item.go`
- `rest/pc/stock_keeping_unit.go`

### 验证
- ✅ 编译通过
- ✅ 不删除字段、不修改字段名、不破坏原有响应结构
- ✅ URL/访问地址字段保留且不受影响