### PR TITLE
feat: 清空商品相关接口响应中的 base64 图片数据

### DIFF
--- a/rest/pc/item.go
+++ b/rest/pc/item.go
@@ -111,6 +111,9 @@ func GetItemList(c fiber.Ctx) error {
 
 	tx.Commit()
 
+	// 清空 base64 图片数据
+	tools.ClearItemListBase64(itemList)
+
 	return c.JSON(tools.Response{
 		Code:    0,
 		Message: "获取商品列表成功",
@@ -658,6 +661,9 @@ func ShowItem(c fiber.Ctx) error {
 	}
 
 	tx.Commit()
+
+	// 清空 base64 图片数据
+	tools.ClearItemBase64(item)
 
 	return c.JSON(tools.Response{
 		Code:    0,

--- a/rest/pc/stock_keeping_unit.go
+++ b/rest/pc/stock_keeping_unit.go
@@ -89,6 +89,9 @@ func GetSkuList(c fiber.Ctx) error {
 
 	tx.Commit()
 
+	// 清空 base64 图片数据
+	tools.ClearSkuBase64(skuList)
+
 	return c.JSON(tools.Response{
 		Code:    0,
 		Message: "获取SKU列表成功",

--- a/tools/clear_base64.go
+++ b/tools/clear_base64.go
@@ -1,0 +1,38 @@
+package tools
+
+import "github.com/sanyuanya/dongle/entity"
+
+// ClearPictureBase64 清空 Picture 结构体中的 base64 图片数据
+func ClearPictureBase64(pictures []*entity.Picture) {
+	for _, pic := range pictures {
+		if pic != nil {
+			pic.ImageData = ""
+		}
+	}
+}
+
+// ClearSkuBase64 清空 Sku 结构体中的 base64 图片数据
+func ClearSkuBase64(skus []*entity.Sku) {
+	for _, sku := range skus {
+		if sku != nil {
+			sku.ImageData = ""
+		}
+	}
+}
+
+// ClearItemBase64 清空 Item 结构体及其关联数据中的 base64 图片数据
+func ClearItemBase64(item *entity.Item) {
+	if item == nil {
+		return
+	}
+	ClearPictureBase64(item.Picture)
+	ClearPictureBase64(item.Detail)
+	ClearSkuBase64(item.Sku)
+}
+
+// ClearItemListBase64 清空 Item 列表中的 base64 图片数据
+func ClearItemListBase64(items []*entity.Item) {
+	for _, item := range items {
+		ClearItemBase64(item)
+	}
+}


### PR DESCRIPTION
## 修改说明
- 新增 `tools/clear_base64.go` 公共清理函数
- 在商品列表、商品详情、SKU 列表响应返回前统一将图片 base64 字段置为空字符串
- 保留 `object_name`、`bucket_name` 等访问地址相关字段，不修改响应结构

## 影响的接口/文件
- 接口
  - `/api/pc/item/list`
  - `/api/pc/item/show/:itemId`
  - `/api/pc/sku/list/:itemId`
- 文件
  - `rest/pc/item.go`
  - `rest/pc/stock_keeping_unit.go`
  - `tools/clear_base64.go`

## 备注
- 当前 PR 内容与误推到 `main` 的提交一致，仅完成现有这部分改动。