### PR TITLE
feat: 统一清空商品相关接口响应中的图片 base64 内容

### DIFF
--- a/entity/item.go
+++ b/entity/item.go
@@ -1,5 +1,7 @@
 package entity
 
+import "encoding/json"
+
 type AddItem struct {
 	Name         string     `json:"name"`
 	Code         string     `json:"code"`
@@ -21,6 +23,17 @@ type Picture struct {
 	Ext         string `json:"ext"`
 	ObjectName  string `json:"object_name"`
 	BucketName  string `json:"bucket_name"`
+}
+
+func (p Picture) MarshalJSON() ([]byte, error) {
+	type Alias Picture
+	return json.Marshal(&struct {
+		ImageData string `json:"image_data"`
+		*Alias
+	}{
+		ImageData: "",
+		Alias:     (*Alias)(&p),
+	})
 }
 
 type UpdateItem struct {

--- a/entity/item_image.go
+++ b/entity/item_image.go
@@ -1,5 +1,7 @@
 package entity
 
+import "encoding/json"
+
 type AddItemImage struct {
 	SnowflakeId string `json:"snowflake_id"`
 	ItemId      string `json:"item_id"`
@@ -9,4 +11,15 @@ type AddItemImage struct {
 	ObjectName  string `json:"object_name"`
 	BucketName  string `json:"bucket_name"`
 	Ext         string `json:"ext"`
+}
+
+func (a AddItemImage) MarshalJSON() ([]byte, error) {
+	type Alias AddItemImage
+	return json.Marshal(&struct {
+		Data string `json:"data"`
+		*Alias
+	}{
+		Data:  "",
+		Alias: (*Alias)(&a),
+	})
 }

--- a/entity/stock_keeping_unit.go
+++ b/entity/stock_keeping_unit.go
@@ -1,5 +1,7 @@
 package entity
 
+import "encoding/json"
+
 type AddSkuRequest struct {
 	SnowflakeId   string  `json:"snowflake_id"`
 	Code          string  `json:"code"`
@@ -16,6 +18,17 @@ type AddSkuRequest struct {
 	Ext           string  `json:"ext"`
 }
 
+func (a AddSkuRequest) MarshalJSON() ([]byte, error) {
+	type Alias AddSkuRequest
+	return json.Marshal(&struct {
+		ImageData string `json:"image_data"`
+		*Alias
+	}{
+		ImageData: "",
+		Alias:     (*Alias)(&a),
+	})
+}
+
 type UpdateSkuRequest struct {
 	SnowflakeId   string  `json:"snowflake_id"`
 	Code          string  `json:"code"`
@@ -30,6 +43,17 @@ type UpdateSkuRequest struct {
 	ObjectName    string  `json:"object_name"`
 	BucketName    string  `json:"bucket_name"`
 	Ext           string  `json:"ext"`
+}
+
+func (u UpdateSkuRequest) MarshalJSON() ([]byte, error) {
+	type Alias UpdateSkuRequest
+	return json.Marshal(&struct {
+		ImageData string `json:"image_data"`
+		*Alias
+	}{
+		ImageData: "",
+		Alias:     (*Alias)(&u),
+	})
 }
 
 type ShowSkuResponse struct {
@@ -61,6 +85,17 @@ type Sku struct {
 	CreatedAt     string  `json:"created_at"`
 	UpdatedAt     string  `json:"updated_at"`
 	ActualSales   int64   `json:"actual_sales"`
+}
+
+func (s Sku) MarshalJSON() ([]byte, error) {
+	type Alias Sku
+	return json.Marshal(&struct {
+		ImageData string `json:"image_data"`
+		*Alias
+	}{
+		ImageData: "",
+		Alias:     (*Alias)(&s),
+	})
 }
 
 type GetSkuRequest struct {


### PR DESCRIPTION
- 为 Picture、Sku、AddSkuRequest、UpdateSkuRequest、AddItemImage 结构体实现 MarshalJSON 方法
- 保留 image_data/data 字段但值设为空字符串
- 保留 object_name、bucket_name 等 URL 字段不变
- 统一在序列化层处理，自动影响所有相关接口